### PR TITLE
Fix document title for ChatGPT clippings

### DIFF
--- a/templates/chatgpt-clipper.json
+++ b/templates/chatgpt-clipper.json
@@ -6,7 +6,7 @@
 	"properties": [
 		{
 			"name": "title",
-			"value": "{{title}}",
+			"value": "{{selector:a[data-active] span}}",
 			"type": "text"
 		},
 		{


### PR DESCRIPTION
The default `{{title}}` selector always return "ChatGPT" as that .md document title. This behavior is changed to search for the name of the active page in the side panel.