### PR TITLE
Delete duplicate categories value in Goodreads file

### DIFF
--- a/templates/goodreads-clipper.json
+++ b/templates/goodreads-clipper.json
@@ -12,11 +12,6 @@
             "type": "multitext"
         },
 		{
-			"name": "categories",
-			"value": "[[Books]]",
-			"type": "multitext"
-		},
-		{
 			"name": "title",
 			"value": "{{selector:.BookPageTitleSection__title h1}}",
 			"type": "text"


### PR DESCRIPTION
The duplicate was added in 06408f858d85be04f56ab2e588f7d850f7718bbd - perhaps by accident...