### PR TITLE
Fix year extraction in goodreads-clipper.json

### DIFF
--- a/templates/goodreads-clipper.json
+++ b/templates/goodreads-clipper.json
@@ -33,7 +33,7 @@
 		},
 		{
 			"name": "year",
-			"value": "{{selector:p[data-testid='publicationInfo']|split:\\\"First published \\\"|slice:1|date:\\\"YYYY\\\"}}",
+			"value": "{{selector:p[data-testid='publicationInfo']|split:" "|last}}",
 			"type": "number"
 		},
 		{


### PR DESCRIPTION
In some cases, the published year is written as "First Published", in other cases it is written as just "Published". But in both cases, it ends with a year, and there is a space before the year. So, proposing this change to split by space and take the last.