### PR TITLE
update year property in goodreads-clipper

### DIFF
--- a/templates/goodreads-clipper.json
+++ b/templates/goodreads-clipper.json
@@ -33,7 +33,7 @@
 		},
 		{
 			"name": "year",
-			"value": "{{selector:p[data-testid='publicationInfo']|split:" "|last}}",
+			"value": "{{selector:p[data-testid='publicationInfo']|split:\\\" \\\"|last}}",
 			"type": "number"
 		},
 		{


### PR DESCRIPTION
Could not import this JSON into Obsidian Clipper.
Modified `split:" "` to `split:\\\" \\\"`.
Import is now successful.