### PR TITLE
recipes: change categories to plural Recipes

### DIFF
--- a/templates/recipes-clipper.json
+++ b/templates/recipes-clipper.json
@@ -6,7 +6,7 @@
 	"properties": [
 		{
 			"name": "categories",
-			"value": "[[Recipe]]",
+			"value": "[[Recipes]]",
 			"type": "multitext"
 		},
 		{


### PR DESCRIPTION
This aligns with [Personal Rule](https://stephango.com/vault#personal-rules), *Always pluralize categories and tags* and the [Recipe Template](https://github.com/kepano/kepano-obsidian/blob/main/Templates/Recipe%20Template.md) and [Recipes Base](https://github.com/kepano/kepano-obsidian/blob/main/Templates/Bases/Recipes.base).