### PR TITLE
Update google-maps-clipper.json to grab correct coordinates

### DIFF
--- a/templates/google-maps-clipper.json
+++ b/templates/google-maps-clipper.json
@@ -28,7 +28,7 @@
 		},
 		{
 			"name": "coordinates",
-			"value": "{{url|split:\\\"/@\\\"|slice:1|split:\\\",\\\"|slice:0,2}}",
+			"value": "{{url|split:"!3d"|slice:1,2|split:"!"|slice:0,2|join:""|split:"4d"|join:","}}",
 			"type": "multitext"
 		},
 		{


### PR DESCRIPTION
A google maps url has the format:

https://www.google.com/maps/place/Washington+Monument/@38.8894583,-77.0377464,1469m/data=!3m2!1e3!4b1!4m6!3m5!1s0x89b7b7a1be0c2e7f:0xe97346828ed0bfb8!8m2!3d38.8894838!4d-77.0352791!16zL20vMDE2ZGZm?entry=ttu&g_ep=EgoyMDI2MDEyOC4wIKXMDSoASAFQAw%3D%3D

The first two coordinates (38.8894583,-77.0377464) are offset from the coordinates of the searched location found later in the url (38.8894838, -77.0352791). This change probably grabs the second set of coordinates.

Alternate scheme by dkaue on discord, but this seems less clean:
`{{url|replace:"/^.+?(?:data=.+?!3d(-?\d+\.\d+)!4d(-?\d+\.\d+).+)?$/":"$1,$2"}}`