### PR TITLE
Fix selectors for Goodreads template

### DIFF
--- a/templates/goodreads-clipper.json
+++ b/templates/goodreads-clipper.json
@@ -53,12 +53,12 @@
 		},
 		{
 			"name": "isbn",
-			"value": "{{selector:.DescList|split:\\\"ISBN\\\"|slice:1,2|split:\\\" \\\"|first}}",
+			"value": "{{schema:@Book:isbn}}",
 			"type": "text"
 		},
 		{
 			"name": "language",
-			"value": "{{selector:.DescList|split:\\\"Language\\\"|last}}",
+			"value": "{{schema:@Book:inLanguage}}",
 			"type": "text"
 		},
 		{

--- a/templates/goodreads-clipper.json
+++ b/templates/goodreads-clipper.json
@@ -28,7 +28,7 @@
 		},
 		{
 			"name": "pages",
-			"value": "{{selector:p[data-testid='pagesFormat'|split:\\\", \\\"|slice:0|split:\\\" \\\"|slice:0}}",
+			"value": "{{selector:p[data-testid='pagesFormat']|split:\\\", \\\"|slice:0|split:\\\" \\\"|slice:0}}",
 			"type": "number"
 		},
 		{


### PR DESCRIPTION
Changes:
- Added closing bracket to fix the `pages` css selector
- Switched `isbn` and `language` to use schema variables to be a little more robust

(`author`, `title`, `pages`, `scoreGr`, and `cover` could also come from the schema metadata, but I didn't want to make currently-unneeded changes without your go-ahead 🙂)