### PR TITLE
Fix arxiv date selectors: use #watermark-tr instead of .ltx_dates

### DIFF
--- a/templates/arxiv-clipper.json
+++ b/templates/arxiv-clipper.json
@@ -23,12 +23,12 @@
 		},
 		{
 			"name": "published",
-			"value": "{{selector:.ltx_dates|replace:\\\"(\\\",\\\"\\\"|replace:\\\")\\\",\\\"\\\"|date:\\\"YYYY-MM-DD\\\"}}",
+			"value": "{{selector:#watermark-tr|replace:\"/.*] /\":\"\"|date:\"YYYY-MM-DD\"}}",
 			"type": "date"
 		},
 		{
 			"name": "year",
-			"value": "{{selector:.ltx_dates|replace:\\\"(\\\",\\\"\\\"|replace:\\\")\\\",\\\"\\\"|date:\\\"YYYY\\\"}}",
+			"value": "{{selector:#watermark-tr|slice:-4}}",
 			"type": "number"
 		},
 		{


### PR DESCRIPTION
The .ltx_dates class no longer exists on arxiv HTML pages. Switch published and year selectors to extract from #watermark-tr which contains the submission date string.